### PR TITLE
Fix compile errors

### DIFF
--- a/Assets/Plugins/KSPAssets/Editor/TextMeshProResolver.cs
+++ b/Assets/Plugins/KSPAssets/Editor/TextMeshProResolver.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using ReeperCommon.Logging;
 using UnityEditor;
 using UnityEngine;
 
@@ -107,6 +106,7 @@ namespace Assets.Plugins.KSPAssets.Editor
 }
 
 
+/*
 Oh.... new version of the free TMPro. Was worried about that. Hmm. Ok. Will do something like this for an update.
 	MOARdV likes this  Like this
 	Quote
@@ -232,3 +232,4 @@ namespace Assets.Plugins.KSPAssets.Editor
 		}
 	}
 }
+*/

--- a/ShipBrowser.Editor.Plugins.csproj
+++ b/ShipBrowser.Editor.Plugins.csproj
@@ -7,12 +7,11 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{C8472733-0053-D3E1-EFF3-A862D0894FB1}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <AssemblyName>Assembly-CSharp-Editor-firstpass</AssemblyName>
+    <AssemblyName>ShipBrowser.Editor.Plugins</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{E097FAD1-6243-4DAD-9C02-E9B9EFC3FFC1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Unity Full v3.5</TargetFrameworkProfile>
+    <TargetFrameworkProfile />
     <CompilerResponseFile></CompilerResponseFile>
     <UnityProjectType>EditorPlugins:7</UnityProjectType>
     <UnityBuildTarget>StandaloneWindows64:19</UnityBuildTarget>

--- a/ShipBrowser.csproj
+++ b/ShipBrowser.csproj
@@ -7,12 +7,11 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{D111DC21-0CE5-124B-5C19-429565D877B8}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <AssemblyName>Assembly-CSharp</AssemblyName>
+    <AssemblyName>ShipBrowser</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{E097FAD1-6243-4DAD-9C02-E9B9EFC3FFC1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Unity Subset v3.5</TargetFrameworkProfile>
+    <TargetFrameworkProfile />
     <CompilerResponseFile></CompilerResponseFile>
     <UnityProjectType>Game:1</UnityProjectType>
     <UnityBuildTarget>StandaloneWindows64:19</UnityBuildTarget>


### PR DESCRIPTION
The TextMeshProResolver.cs file has a using statement for ReeperCommon.Logging, which my system doesn't have, and there's some non-code text in the middle of the file followed by a repeat of the code. All of those things can stop the project from compiling.

In the csproj files, the other KSP mod projects that I've seen don't use TargetFrameworkIdentifier or TargetFrameworkProfile, and I think that was confusing the compiler as well.

After these changes, I'm able to compile the projects.